### PR TITLE
Back out Bad Version Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v1.0.0
+v0.4.1
 ====
 - Initial fork from https://github.com/therealklanni/guppy-cli with changes to make it compatible with Hudl multiverse directory structure
 - Bumped version from 0.4.0 to 1.0.0 to make for better semver experience

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guppy-cli",
-  "version": "1.0.0",
+  "version": "0.4.1",
   "description": "Commandline functionality for git-guppy",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
backed out major version bump because we want guppy-githook npm packages to resolve properly using our registry
